### PR TITLE
fix: CastAddBodyCodec.decode

### DIFF
--- a/contracts/protobufs/message.proto.sol
+++ b/contracts/protobufs/message.proto.sol
@@ -1377,7 +1377,7 @@ library CastAddBodyCodec {
                 return (false, pos, instance);
             }
 
-            // Impossible to check the ascending order here since parent_url has a key of 7
+            // Impossible to check the ascending order here since parent_url has a key = 7
 
             // Check that the wire type is correct
             success = check_key(field_number, wire_type);

--- a/contracts/protobufs/message.proto.sol
+++ b/contracts/protobufs/message.proto.sol
@@ -1377,10 +1377,7 @@ library CastAddBodyCodec {
                 return (false, pos, instance);
             }
 
-            // Check that the field number of monotonically increasing
-            if (field_number <= previous_field_number) {
-                return (false, pos, instance);
-            }
+            // Impossible to check the ascending order here since parent_url has a key of 7
 
             // Check that the wire type is correct
             success = check_key(field_number, wire_type);

--- a/test/test.ts
+++ b/test/test.ts
@@ -81,6 +81,43 @@ describe('Test decodings', async () => {
         );
     });
 
+    it('CastAddBody with parentUrl', async () => {
+      const message_data: MessageData = {
+        type: MessageType.CAST_ADD,
+        fid,
+        timestamp,
+        network: FarcasterNetwork.MAINNET,
+        castAddBody: {
+          embedsDeprecated: [],
+          mentions: [1],
+          parentUrl: "url",
+          text: '@dwr.eth dau goes brrr',
+          mentionsPositions: [1],
+          embeds: [],
+        }
+      };
+  
+      const signature = await signFarcasterMessage(ed25519Signer, message_data);
+      const public_key = (await ed25519Signer.getSignerKey())._unsafeUnwrap();
+  
+      const message = (MessageData.encode(message_data).finish());
+  
+      const tx = test.verifyCastAddMessage(
+        public_key,
+        signature.r,
+        signature.s,
+        message
+      );
+
+      await expect(tx)
+        .to.emit(test, 'MessageCastAddVerified')
+        .withArgs(
+          message_data.fid,
+          message_data.castAddBody?.text,
+          message_data.castAddBody?.mentions
+        );
+    });
+
     it('ReactionBody', async () => {
       const message_data: MessageData = {
         type: MessageType.REACTION_ADD,


### PR DESCRIPTION
As the protocol [spec](https://github.com/farcasterxyz/protocol/blob/main/docs/SPECIFICATION.md#24-casts) mentions, the `parent_url` key within `CastAddBody ` is `7`. For this reason it's not possible to check the ascending order